### PR TITLE
Fix broken link to GitHub repo in index.html

### DIFF
--- a/apps/remote/src/index.html
+++ b/apps/remote/src/index.html
@@ -196,7 +196,7 @@
 				A local <code>stdio</code> version is also available on npm as
 				<a href="https://npmx.dev/package/@e18e/mcp">@e18e/mcp</a>, with
 				per-client setup instructions in
-				<a href="https://github.com/e18e/e18e-mcp#readme">the README</a>.
+				<a href="https://github.com/e18e/mcp#readme">the README</a>.
 			</p>
 
 			<h2>What it exposes</h2>
@@ -222,7 +222,7 @@
 			</ul>
 
 			<footer>
-				<a href="https://github.com/e18e/e18e-mcp">Source on GitHub</a> &middot;
+				<a href="https://github.com/e18e/mcp">Source on GitHub</a> &middot;
 				<a href="https://e18e.dev">e18e.dev</a>
 			</footer>
 		</main>


### PR DESCRIPTION
As titled, the links in the index.html point to https://github.com/e18e/e18e-mcp which does not exist, so I update it to https://github.com/e18e/mcp